### PR TITLE
fix/all_metrics

### DIFF
--- a/src/components/avsTab/AddMetrics.tsx
+++ b/src/components/avsTab/AddMetrics.tsx
@@ -17,7 +17,7 @@ export const AddMetricsModal: React.FC<AddMetricsProps> = ({
   const code = `https://docs.ivynet.dev/docs/client/AVSstartup`;
 
   const handleClose = () => {
-    navigate('/metrics');  // This will navigate back to the metrics page
+    navigate('/metrics/all');  // This will navigate back to the metrics page
     if (onClose) {
       onClose();
     }

--- a/src/components/avsTab/index.tsx
+++ b/src/components/avsTab/index.tsx
@@ -206,7 +206,7 @@ export const AvsTab: React.FC = () => {
         throw new Error('Machine ID not found');
       }
 
-      const response = await apiFetch(`machine/${machineId}/metrics?avs_name=${avsName}`, 'GET');
+      const response = await apiFetch(`machine/${machineId}/metrics/all?avs_name=${avsName}`, 'GET');
       if (response.data) {
         setMetrics(response.data);
       }


### PR DESCRIPTION
This pull request includes changes to the `src/components/avsTab` directory to modify the navigation and API endpoints for the metrics page. The most important changes are:

Navigation Update:
* [`src/components/avsTab/AddMetrics.tsx`](diffhunk://#diff-99fb684b0d6edd90d09a6c3c561309c35f6933965a70bfa06d0ed2ce3922e32eL20-R20): Updated the `navigate` function to redirect to `/metrics/all` instead of `/metrics`.

API Endpoint Update:
* [`src/components/avsTab/index.tsx`](diffhunk://#diff-4c2369c7b1b5b3401fedf9f04c73aa4cc64207b81752a6d998b680001b3f85b4L209-R209): Modified the API endpoint in the `apiFetch` call to include `/metrics/all` instead of `/metrics`.